### PR TITLE
Add card settings to the card request model

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,21 @@ user.getCards().then { (cards: [Card]) -> () in
 }
 ```
 
+### Create a new card for the user
+
+```swift
+let cardRequest: CardRequest = CardRequest(currency: "foo", label: "BTC", settings: CardSettings(position: 1, starred: true))
+
+// Or just create a card without specifying the card settings.
+// let cardRequest: CardRequest = CardRequest(currency: "foo", label: "BTC")
+
+user.createCard(cardRequest).then { (card: Card) -> () in
+    /// Do something with the card.        
+}.error { (error: ErrorType) -> Void in
+    /// Do something with the error.            
+}
+```
+
 ### Get ticker
 
 ```swift

--- a/Source/Model/Card/CardRequest.swift
+++ b/Source/Model/Card/CardRequest.swift
@@ -10,6 +10,9 @@ public class CardRequest: Mappable {
     /// The label of the card.
     public private(set) final var label: String?
 
+    /// The card settings.
+    public private(set) final var settings: CardSettings?
+
     /**
       Constructor.
 
@@ -19,6 +22,19 @@ public class CardRequest: Mappable {
     public init(currency: String, label: String) {
         self.currency = currency
         self.label = label
+    }
+
+    /**
+      Constructor.
+
+      - parameter currency: The currency of the card.
+      - parameter label: The label of the card.
+      - parameter settings: The settings of the card.
+    */
+    public init(currency: String, label: String, settings: CardSettings) {
+        self.currency = currency
+        self.label = label
+        self.settings = settings
     }
 
     // MARK: Required by the ObjectMapper.
@@ -39,6 +55,7 @@ public class CardRequest: Mappable {
     public func mapping(map: Map) {
         currency  <- map["currency"]
         label <- map["label"]
+        settings <- map["settings"]
     }
 
 }

--- a/Tests/Integration/Model/UserTest.swift
+++ b/Tests/Integration/Model/UserTest.swift
@@ -22,6 +22,21 @@ class UserTest: UpholdTestCase {
         wait()
     }
 
+    func testCreateCardWithSettingsShouldReturnTheCard() {
+        let cardSettings: CardSettings = CardSettings(position: 1, starred: true)
+        let expectation = expectationWithDescription("User test: create card.")
+        let user: User = Fixtures.loadUser()
+        user.adapter = MockRestAdapter(body: Mapper().toJSONString(Fixtures.loadCard(["id": "foobar"]))!)
+
+        user.createCard(CardRequest(currency: "foo", label: "BTC", settings: cardSettings)).then { (card: Card) -> () in
+            XCTAssertEqual(card.id, "foobar", "Failed: Wrong card id.")
+
+            expectation.fulfill()
+        }
+
+        wait()
+    }
+
     func testGetBalancesByCurrencyShouldReturnTheCurrencyBalance() {
         let expectation = expectationWithDescription("User test: get balances by currency.")
         let json: String = "{" +


### PR DESCRIPTION
This PR adds the ability to specify, at the creation process, the card position and if it should be favourite by default.