### PR TITLE
Allow transaction commit request with empty message

### DIFF
--- a/Source/Model/Transaction/TransactionCommitRequest.swift
+++ b/Source/Model/Transaction/TransactionCommitRequest.swift
@@ -25,7 +25,7 @@ open class TransactionCommitRequest: Mappable {
       - parameter message: The transaction message.
       - parameter securityCode: The transaction security code.
     */
-    public init(message: String, securityCode: String) {
+    public init(message: String?, securityCode: String) {
         self.message = message
         self.securityCode = securityCode
     }

--- a/Tests/UnitTests/GlobalConfigurationProductionTest.swift
+++ b/Tests/UnitTests/GlobalConfigurationProductionTest.swift
@@ -13,7 +13,7 @@ class GlobalConfigurationProductionTest: XCTestCase {
     }
 
     func testUpholdSdkVersionShouldReturnSdkVersion() {
-        XCTAssertEqual(GlobalConfigurations.UPHOLD_SDK_VERSION, "0.10s.0", "Failed: Wrong URL value.")
+        XCTAssertEqual(GlobalConfigurations.UPHOLD_SDK_VERSION, "0.11.0", "Failed: Wrong URL value.")
     }
 
 }


### PR DESCRIPTION
This PR updates the transaction commit request to allow empty messages.