### PR TITLE
Add Node model to transaction origin and destination

### DIFF
--- a/Source/Model/Transaction/Destination.swift
+++ b/Source/Model/Transaction/Destination.swift
@@ -34,6 +34,9 @@ open class Destination: Mappable {
     /// The fee from the destination of the transaction.
     public private(set) final var merchant: Merchant?
 
+    /// The node from the destination of the transaction.
+    public private(set) final var node: Node?
+
     /// The rate from the destination of the transaction.
     public private(set) final var rate: String?
 
@@ -56,11 +59,12 @@ open class Destination: Mappable {
       - parameter description: The description from the destination of the transaction.
       - parameter fee: The fee from the destination of the transaction.
       - parameter merchant: The merchant from the destination of the transaction.
+      - parameter node: The node from the destination of the transaction.
       - parameter rate: The rate from the destination of the transaction.
       - parameter type: The type from the destination of the transaction.
       - parameter username: The username from the destination of the transaction.
     */
-    public init(accountId: String, cardId: String, accountType: String, amount: String, base: String, commission: String, currency: String, description: String, fee: String, merchant: Merchant, rate: String, type: String, username: String) {
+    public init(accountId: String, cardId: String, accountType: String, amount: String, base: String, commission: String, currency: String, description: String, fee: String, merchant: Merchant, node: Node, rate: String, type: String, username: String) {
         self.accountId = accountId
         self.cardId = cardId
         self.accountType = accountType
@@ -71,6 +75,7 @@ open class Destination: Mappable {
         self.description = description
         self.fee = fee
         self.merchant = merchant
+        self.node = node
         self.rate = rate
         self.type = type
         self.username = username
@@ -102,6 +107,7 @@ open class Destination: Mappable {
         description <- map["description"]
         fee <- map["fee"]
         merchant <- map["merchant"]
+        node <- map["node"]
         rate <- map["rate"]
         type <- map["type"]
         username <- map["username"]

--- a/Source/Model/Transaction/Node.swift
+++ b/Source/Model/Transaction/Node.swift
@@ -1,0 +1,50 @@
+import Foundation
+import ObjectMapper
+
+/// Node model.
+open class Node: Mappable {
+
+    /// The brand.
+    public private(set) final var brand: String?
+
+    /// The id.
+    public private(set) final var id: String?
+
+    /// The type.
+    public private(set) final var type: String?
+
+    /**
+      Constructor.
+
+      - parameter brand: The brand.
+      - parameter id: The id.
+      - parameter type: The type.
+    */
+    public init(brand: String, id: String, type: String) {
+        self.brand = brand
+        self.id = type
+        self.type = type
+    }
+
+    // MARK: Required by the ObjectMapper.
+
+    /**
+      Constructor.
+
+      - parameter map: Mapping data object.
+    */
+    required public init?(map: Map) {
+    }
+
+    /**
+      Maps the JSON to the Object.
+
+      - parameter map: The object to map.
+    */
+    open func mapping(map: Map) {
+        brand  <- map["brand"]
+        id <- map["id"]
+        type <- map["type"]
+    }
+
+}

--- a/Source/Model/Transaction/Origin.swift
+++ b/Source/Model/Transaction/Origin.swift
@@ -34,6 +34,9 @@ open class Origin: Mappable {
     /// The merchant from the origin of the transaction.
     public private(set) final var merchant: Merchant?
 
+    /// The node from the origin of the transaction.
+    public private(set) final var node: Node?
+
     /// The rate from the origin of the transaction.
     public private(set) final var rate: String?
 
@@ -59,12 +62,13 @@ open class Origin: Mappable {
       - parameter description: The description from the origin of the transaction.
       - parameter fee: The fee from the origin of the transaction.
       - parameter merchant: The merchant from the origin of the transaction.
+      - parameter node: The node from the origin of the transaction.
       - parameter rate: The rate from the origin of the transaction.
       - parameter sources: The sources from the origin of the transaction.
       - parameter type: The type from the origin of the transaction.
       - parameter username: The username from the origin of the transaction.
     */
-    public init(accountId: String, cardId: String, accountType: String, amount: String, base: String, commission: String, currency: String, description: String, fee: String, merchant: Merchant, rate: String, sources: [Source], type: String, username: String) {
+    public init(accountId: String, cardId: String, accountType: String, amount: String, base: String, commission: String, currency: String, description: String, fee: String, merchant: Merchant, node: Node, rate: String, sources: [Source], type: String, username: String) {
         self.accountId = accountId
         self.cardId = cardId
         self.accountType = accountType
@@ -75,6 +79,7 @@ open class Origin: Mappable {
         self.description = description
         self.fee = fee
         self.merchant = merchant
+        self.node = node
         self.rate = rate
         self.sources = sources
         self.type = type
@@ -107,6 +112,7 @@ open class Origin: Mappable {
         description <- map["description"]
         fee <- map["fee"]
         merchant <- map["merchant"]
+        node <- map["node"]
         rate <- map["rate"]
         sources <- map["sources"]
         type <- map["type"]

--- a/Tests/IntegrationTests/ModelTests/TransactionTest.swift
+++ b/Tests/IntegrationTests/ModelTests/TransactionTest.swift
@@ -408,6 +408,11 @@ class TransactionTest: UpholdTestCase {
                     "\"state\": \"foobiz\"," +
                     "\"zipCode\": \"foobuz\"," +
                 "}," +
+                "\"node\": {" +
+                    "\"brand\": \"foobar\"," +
+                    "\"id\": \"bar\"," +
+                    "\"type\": \"foobiz\"," +
+                "}," +
                 "\"rate\": \"1.00\"," +
                 "\"sources\": [{" +
                     "\"id\": \"fizbuz\"," +
@@ -430,7 +435,12 @@ class TransactionTest: UpholdTestCase {
                     "\"country\": \"bar\"," +
                     "\"name\": \"foobar\"," +
                     "\"state\": \"foobiz\"," +
-                    "\"zipCode\": \"foobuz\"," +
+                    "\"zipCode\": \"foobuz\"" +
+                "}," +
+                "\"node\": {" +
+                    "\"brand\": \"foo\"," +
+                    "\"id\": \"bar\"," +
+                    "\"type\": \"foobar\"" +
                 "}," +
                 "\"rate\": \"1.00\"," +
                 "\"type\": \"email\"," +
@@ -483,6 +493,9 @@ class TransactionTest: UpholdTestCase {
         XCTAssertEqual(transaction!.destination!.merchant!.name!, "foobar", "Failed: Transaction destination merchant name didn't match.")
         XCTAssertEqual(transaction!.destination!.merchant!.state!, "foobiz", "Failed: Transaction destination merchant state didn't match.")
         XCTAssertEqual(transaction!.destination!.merchant!.zipCode!, "foobuz", "Failed: Transaction destination merchant zip code didn't match.")
+        XCTAssertEqual(transaction!.destination!.node!.brand!, "foo", "Failed: Transaction destination node brand didn't match.")
+        XCTAssertEqual(transaction!.destination!.node!.id!, "bar", "Failed: Transaction destination node id didn't match.")
+        XCTAssertEqual(transaction!.destination!.node!.type!, "foobar", "Failed: Transaction destination node type didn't match.")
         XCTAssertEqual(transaction!.destination!.rate!, "1.00", "Failed: Transaction destination rate didn't match.")
         XCTAssertEqual(transaction!.destination!.type!, "email", "Failed: Transaction destination type didn't match.")
         XCTAssertEqual(transaction!.destination!.username!, "fizbiz", "Failed: Transaction destination username didn't match.")
@@ -512,6 +525,9 @@ class TransactionTest: UpholdTestCase {
         XCTAssertEqual(transaction!.origin!.merchant!.name!, "foobar", "Failed: Transaction origin merchant name didn't match.")
         XCTAssertEqual(transaction!.origin!.merchant!.state!, "foobiz", "Failed: Transaction origin merchant state didn't match.")
         XCTAssertEqual(transaction!.origin!.merchant!.zipCode!, "foobuz", "Failed: Transaction origin merchant zip code didn't match.")
+        XCTAssertEqual(transaction!.origin!.node!.brand!, "foobar", "Failed: Transaction origin node brand didn't match.")
+        XCTAssertEqual(transaction!.origin!.node!.id!, "bar", "Failed: Transaction origin node id didn't match.")
+        XCTAssertEqual(transaction!.origin!.node!.type!, "foobiz", "Failed: Transaction origin node type didn't match.")
         XCTAssertEqual(transaction!.origin!.rate!, "1.00", "Failed: Transaction origin rate didn't match.")
         XCTAssertEqual(transaction!.origin!.sources!.count, 1, "Failed: Transaction origin type didn't match.")
         XCTAssertEqual(transaction!.origin!.sources![0].id!, "fizbuz", "Failed: Transaction origin type didn't match.")

--- a/Tests/UtilTests/Fixtures.swift
+++ b/Tests/UtilTests/Fixtures.swift
@@ -133,6 +133,9 @@ public class Fixtures {
             "destinationMerchantName": faker.company.name(),
             "destinationMerchantState": faker.address.state(),
             "destinationMerchantZipCode": faker.address.postcode(),
+            "destinationNodeBrand": faker.lorem.characters(amount: 9),
+            "destinationNodeId": faker.lorem.characters(amount: 9),
+            "destinationNodeType": faker.lorem.characters(amount: 6),
             "destinationRate": faker.lorem.characters(amount: 3),
             "destinationType": faker.lorem.characters(amount: 6),
             "destinationUsername": faker.lorem.characters(amount: 10),
@@ -160,6 +163,9 @@ public class Fixtures {
             "originMerchantName": faker.company.name(),
             "originMerchantState": faker.address.state(),
             "originMerchantZipCode": faker.address.postcode(),
+            "originNodeBrand": faker.lorem.characters(amount: 9),
+            "originNodeId": faker.lorem.characters(amount: 9),
+            "originNodeType": faker.lorem.characters(amount: 6),
             "originRate": faker.lorem.numerify("123456789"),
             "originSourcesAmount": String(format: "%@,%@,%@", faker.lorem.numerify("123456789"), faker.lorem.numerify("123456789"), faker.lorem.numerify("123456789")),
             "originSourcesId": String(format: "%@,%@,%@", faker.lorem.characters(amount: 24), faker.lorem.characters(amount: 24), faker.lorem.characters(amount: 24)),
@@ -189,8 +195,9 @@ public class Fixtures {
         }
 
         let destinationMerchant = Merchant(city: fakerFields["destinationMerchantCity"]!, country: fakerFields["destinationMerchantCountry"]!, name: fakerFields["destinationMerchantName"]!, state: fakerFields["destinationMerchantState"]!, zipCode: fakerFields["destinationMerchantZipCode"]!)
+        let destinationNode = Node(brand: fakerFields["destinationNodeBrand"]!, id: fakerFields["destinationNodeId"]!, type: fakerFields["destinationNodeType"]!)
         let denomination = Denomination(amount: fakerFields["denominationAmount"]!, currency: fakerFields["denominationCurrency"]!, pair: fakerFields["denominationPair"]!, rate: fakerFields["denominationRate"]!)
-        let destination = Destination(accountId: fakerFields["destinationAccountId"]!, cardId: fakerFields["destinationCardId"]!, accountType: fakerFields["destinationAccountType"]!, amount: fakerFields["destinationAmount"]!, base: fakerFields["destinationBase"]!, commission: fakerFields["destinationCommission"]!, currency: fakerFields["destinationCurrency"]!, description: fakerFields["destinationDescription"]!, fee: fakerFields["destinationFee"]!, merchant: destinationMerchant, rate: fakerFields["destinationRate"]!, type: fakerFields["destinationType"]!, username: fakerFields["destinationUsername"]!)
+        let destination = Destination(accountId: fakerFields["destinationAccountId"]!, cardId: fakerFields["destinationCardId"]!, accountType: fakerFields["destinationAccountType"]!, amount: fakerFields["destinationAmount"]!, base: fakerFields["destinationBase"]!, commission: fakerFields["destinationCommission"]!, currency: fakerFields["destinationCurrency"]!, description: fakerFields["destinationDescription"]!, fee: fakerFields["destinationFee"]!, merchant: destinationMerchant, node: destinationNode, rate: fakerFields["destinationRate"]!, type: fakerFields["destinationType"]!, username: fakerFields["destinationUsername"]!)
         let fees = [Fee(amount: fakerFields["feeAmount"]!, currency: fakerFields["feeCurrency"]!, percentage: fakerFields["feePercentage"]!, target: fakerFields["feeTarget"]!, type: fakerFields["feeType"]!)]
         var sources: [Source] = []
 
@@ -199,8 +206,9 @@ public class Fixtures {
         }
 
         let originMerchant = Merchant(city: fakerFields["originMerchantCity"]!, country: fakerFields["originMerchantCountry"]!, name: fakerFields["originMerchantName"]!, state: fakerFields["originMerchantState"]!, zipCode: fakerFields["originMerchantZipCode"]!)
+        let originNode = Node(brand: fakerFields["originNodeBrand"]!, id: fakerFields["originNodeId"]!, type: fakerFields["originNodeType"]!)
         let normalized = [NormalizedTransaction(amount: fakerFields["normalizedAmount"]!, commission: fakerFields["normalizedCommission"]!, currency: fakerFields["normalizedCurrency"]!, fee: fakerFields["normalizedFee"]!, rate: fakerFields["normalizedRate"]!)]
-        let origin = Origin(accountId: fakerFields["originAccountId"]!, cardId: fakerFields["originCardId"]!, accountType: fakerFields["originAccountType"]!, amount: fakerFields["originAmount"]!, base: fakerFields["originBase"]!, commission: fakerFields["originCommission"]!, currency: fakerFields["originCurrency"]!, description: fakerFields["originDescription"]!, fee: fakerFields["originFee"]!, merchant: originMerchant, rate: fakerFields["originRate"]!, sources: sources, type: fakerFields["originType"]!, username: fakerFields["originUsername"]!)
+        let origin = Origin(accountId: fakerFields["originAccountId"]!, cardId: fakerFields["originCardId"]!, accountType: fakerFields["originAccountType"]!, amount: fakerFields["originAmount"]!, base: fakerFields["originBase"]!, commission: fakerFields["originCommission"]!, currency: fakerFields["originCurrency"]!, description: fakerFields["originDescription"]!, fee: fakerFields["originFee"]!, merchant: originMerchant, node: originNode, rate: fakerFields["originRate"]!, sources: sources, type: fakerFields["originType"]!, username: fakerFields["originUsername"]!)
         let parameters = Parameters(currency: fakerFields["parametersCurrency"]!, margin: fakerFields["parametersMargin"]!, pair: fakerFields["parametersPair"]!, progress: fakerFields["parametersProgress"]!, rate: fakerFields["parametersRate"]!, refunds: fakerFields["parametersRefunds"]!, ttl: NSString(string: fakerFields["parametersTtl"]!).integerValue, txid: fakerFields["parametersTxid"]!, type: fakerFields["parametersType"]!)
 
         return Transaction(id: fakerFields["transactionId"]!, createdAt: fakerFields["transactionCreatedAt"]!, denomination: denomination, destination: destination, fees: fees, message: fakerFields["transactionMessage"]!, network: fakerFields["transactionNetwork"]!, normalized: normalized, origin: origin, params: parameters, refundedById: fakerFields["transactionRefundedById"]!, status: fakerFields["transactionStatus"]!, type: fakerFields["transactionType"]!)

--- a/UpholdSdk.xcodeproj/project.pbxproj
+++ b/UpholdSdk.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		2ABB18FB1FC3282E0098A87D /* VerificationParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ABB18F91FC3282E0098A87D /* VerificationParameter.swift */; };
 		2ABB18FD1FC3294D0098A87D /* Verifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ABB18FC1FC3294D0098A87D /* Verifications.swift */; };
 		2ABB18FE1FC3294D0098A87D /* Verifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ABB18FC1FC3294D0098A87D /* Verifications.swift */; };
+		2AFF8F9D201124BC003BC0F7 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AFF8F9C201124BC003BC0F7 /* Node.swift */; };
+		2AFF8F9E201124BC003BC0F7 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AFF8F9C201124BC003BC0F7 /* Node.swift */; };
 		BC02EB191C10503C00FCA0D9 /* TransactionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC02EB181C10503C00FCA0D9 /* TransactionRequest.swift */; };
 		BC02EB1B1C1051B500FCA0D9 /* TransactionDenominationRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC02EB1A1C1051B500FCA0D9 /* TransactionDenominationRequest.swift */; };
 		BC0C90231C4CF40400AD0F99 /* OAuth2ServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC0C90221C4CF40400AD0F99 /* OAuth2ServiceTest.swift */; };
@@ -271,6 +273,7 @@
 		2A75796D1E9B9C670071BBCA /* Document.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Document.swift; sourceTree = "<group>"; };
 		2ABB18F91FC3282E0098A87D /* VerificationParameter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerificationParameter.swift; sourceTree = "<group>"; };
 		2ABB18FC1FC3294D0098A87D /* Verifications.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Verifications.swift; sourceTree = "<group>"; };
+		2AFF8F9C201124BC003BC0F7 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		BC02EB181C10503C00FCA0D9 /* TransactionRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionRequest.swift; sourceTree = "<group>"; };
 		BC02EB1A1C1051B500FCA0D9 /* TransactionDenominationRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionDenominationRequest.swift; sourceTree = "<group>"; };
 		BC0C90221C4CF40400AD0F99 /* OAuth2ServiceTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuth2ServiceTest.swift; sourceTree = "<group>"; };
@@ -533,6 +536,7 @@
 			isa = PBXGroup;
 			children = (
 				BC2381521BB4626F0060CC80 /* Denomination.swift */,
+				2AFF8F9C201124BC003BC0F7 /* Node.swift */,
 				BC2381531BB4626F0060CC80 /* Destination.swift */,
 				BCF4D37E1C62112D00E4BDDA /* Fee.swift */,
 				BC81F7011C0753BA0025A1AF /* NormalizedTransaction.swift */,
@@ -1226,6 +1230,7 @@
 				BCC392FD1CE645FA00091B19 /* AccountsService.swift in Sources */,
 				BC2381621BB4626F0060CC80 /* UpholdClient.swift in Sources */,
 				BC12F44F1C10691E00EB2E2B /* TransactionCommitRequest.swift in Sources */,
+				2AFF8F9D201124BC003BC0F7 /* Node.swift in Sources */,
 				2A6DB55C1D1ECB1A00D98D32 /* AddressRequest.swift in Sources */,
 				BC2381731BB4626F0060CC80 /* ReserveService.swift in Sources */,
 				BC98A4B61C3BE80B00C60A3D /* GlobalConfigurations.swift in Sources */,
@@ -1389,6 +1394,7 @@
 				BCC392FE1CE645FA00091B19 /* AccountsService.swift in Sources */,
 				BCC9D7031C56377E00671171 /* UpholdClient.swift in Sources */,
 				BCC9D7041C56377E00671171 /* TransactionCommitRequest.swift in Sources */,
+				2AFF8F9E201124BC003BC0F7 /* Node.swift in Sources */,
 				2A6DB55D1D1ECB1A00D98D32 /* AddressRequest.swift in Sources */,
 				BCC9D7051C56377E00671171 /* ReserveService.swift in Sources */,
 				BCC9D7061C56377E00671171 /* GlobalConfigurations.swift in Sources */,


### PR DESCRIPTION
This PR adds the `Node` model to the transaction `origin` and `destination`.