### PR TITLE
Add support for transaction destination address

### DIFF
--- a/Source/Model/Transaction/Destination.swift
+++ b/Source/Model/Transaction/Destination.swift
@@ -13,6 +13,9 @@ open class Destination: Mappable {
     /// The type of the account from the destination of the transaction.
     public private(set) final var accountType: String?
 
+    /// The address from the destination of the transaction.
+    public private(set) final var address: String?
+
     /// The amount from the destination of the transaction.
     public private(set) final var amount: String?
 
@@ -52,6 +55,7 @@ open class Destination: Mappable {
       - parameter accountId: The id of the account from the destination of the transaction.
       - parameter cardId: The card id of the card from the destination of the transaction.
       - parameter accountType: The type of the account from the destination of the transaction.
+      - parameter address: The address from the destination of the transaction.
       - parameter amount: The amount from the destination of the transaction.
       - parameter base: The base from the destination of the transaction.
       - parameter commission: The commission from the destination of the transaction.
@@ -64,8 +68,9 @@ open class Destination: Mappable {
       - parameter type: The type from the destination of the transaction.
       - parameter username: The username from the destination of the transaction.
     */
-    public init(accountId: String, cardId: String, accountType: String, amount: String, base: String, commission: String, currency: String, description: String, fee: String, merchant: Merchant, node: Node, rate: String, type: String, username: String) {
+    public init(accountId: String, cardId: String, accountType: String, address: String, amount: String, base: String, commission: String, currency: String, description: String, fee: String, merchant: Merchant, node: Node, rate: String, type: String, username: String) {
         self.accountId = accountId
+        self.address = address
         self.cardId = cardId
         self.accountType = accountType
         self.amount = amount
@@ -100,6 +105,7 @@ open class Destination: Mappable {
         accountId  <- map["AccountId"]
         cardId  <- map["CardId"]
         accountType <- map["accountType"]
+        address <- map["address"]
         amount <- map["amount"]
         base <- map["base"]
         commission <- map["commission"]

--- a/Tests/IntegrationTests/ModelTests/TransactionTest.swift
+++ b/Tests/IntegrationTests/ModelTests/TransactionTest.swift
@@ -424,6 +424,7 @@ class TransactionTest: UpholdTestCase {
             "\"destination\": {" +
                 "\"AccountId\": \"fizbuz\"," +
                 "\"CardId\": \"fuzbuz\"," +
+                "\"address\": \"a1b2c3d4e5f6g7h8j9101112\"," +
                 "\"amount\": \"0.1\"," +
                 "\"base\": \"0.1\"," +
                 "\"commission\": \"0.00\"," +
@@ -482,6 +483,7 @@ class TransactionTest: UpholdTestCase {
         XCTAssertEqual(transaction!.denomination!.rate!, "1.00", "Failed: Transaction denomination rate didn't match.")
         XCTAssertEqual(transaction!.destination!.accountId!, "fizbuz", "Failed: Transaction destination accountId didn't match.")
         XCTAssertEqual(transaction!.destination!.cardId!, "fuzbuz", "Failed: Transaction destination cardId didn't match.")
+        XCTAssertEqual(transaction!.destination!.address!, "a1b2c3d4e5f6g7h8j9101112", "Failed: Transaction destination address didn't match.")
         XCTAssertEqual(transaction!.destination!.amount!, "0.1", "Failed: Transaction destination amount didn't match.")
         XCTAssertEqual(transaction!.destination!.base!, "0.1", "Failed: Transaction destination base didn't match.")
         XCTAssertEqual(transaction!.destination!.commission!, "0.00", "Failed: Transaction destination commission didn't match.")

--- a/Tests/UtilTests/Fixtures.swift
+++ b/Tests/UtilTests/Fixtures.swift
@@ -121,6 +121,7 @@ public class Fixtures {
             "denominationRate": faker.lorem.numerify("123456789"),
             "destinationAccountId": faker.lorem.numerify("123456789"),
             "destinationAccountType": faker.lorem.characters(amount: 7),
+            "destinationAddress": faker.lorem.characters(amount: 20),
             "destinationAmount": faker.lorem.numerify("123456789"),
             "destinationBase": faker.lorem.numerify("123456789"),
             "destinationCardId": faker.lorem.characters(amount: 24),


### PR DESCRIPTION
This PR adds the support for the field `address` at the destination of the transaction.